### PR TITLE
feat: Ignore scratchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Usage
 Add this line to your i3 or Sway configuration:
 
 ```
-exec_always i3-focus-last server
+exec_always i3-focus-last server <--ignore-scratchpad>
 ```
 
 Then, add a binding to execute `i3-focus-last`:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ exec_always i3-focus-last server
 Then, add a binding to execute `i3-focus-last`:
 
 ```
-bindsym $mod+Tab exec i3-focus-last <--ignore-scratchpad> <--hide-scratchpad>
+bindsym $mod+Tab exec i3-focus-last switch <--ignore-scratchpad> <--hide-scratchpad>
 ```
 
 Options

--- a/README.md
+++ b/README.md
@@ -20,14 +20,19 @@ Usage
 Add this line to your i3 or Sway configuration:
 
 ```
-exec_always i3-focus-last server <--ignore-scratchpad>
+exec_always i3-focus-last server
 ```
 
 Then, add a binding to execute `i3-focus-last`:
 
 ```
-bindsym $mod+Tab exec i3-focus-last
+bindsym $mod+Tab exec i3-focus-last <--ignore-scratchpad> <--hide-scratchpad>
 ```
+
+Options
+--------
+- `--ignore-scratchpad` - Don't focus to/from scratchpad
+- `--hide-scratchpad` - If scratchpad is focused, hide it and focus previous window
 
 Menu mode
 ---------

--- a/src/main.rs
+++ b/src/main.rs
@@ -414,7 +414,7 @@ enum ProgCommand {
 struct SwitchOpts {
     #[options(help = "nth window to focus", no_long, short = "n", default = "1")]
     count: usize,
-    #[options(help = "Don't count scratchpad", long = "ignore-scratchpad")]
+    #[options(help = "Don't count scratchpad", long = "ignore-scratchpad", default = "true")]
     ignore_scratchpad: bool,
     #[options(help = "If scratchpad focused, hide it", long = "hide-scratchpad")]
     hide_scratchpad: bool,
@@ -460,8 +460,7 @@ fn main() {
         _ => {
             let opts = SwitchOpts {
                 count: 1,
-                // remain compatible with previous behavior
-                ignore_scratchpad: false,
+                ignore_scratchpad: true,
                 hide_scratchpad: false,
             };
             focus_client(opts);


### PR DESCRIPTION
This PR adds command line options to:
- Ignore the scratchpad when switching focus
- Hide the scratchpad if it's currently focused before switching to the previous window

Usecases:
- Bringing up scratchpad for something quick and wanting to yeet it away afterwards.
- Having a reference window open in scratchpad while also toggling between different windows.